### PR TITLE
Fix error with tilemap entity

### DIFF
--- a/engine/src/ecs/scene.h
+++ b/engine/src/ecs/scene.h
@@ -43,7 +43,7 @@ FUSE_INLINE void start() {
   tm->instance.tilesize = 64;
 
   // add tilemap entity
-  auto& tilemap = add_entity("tilemap");
+  ecs::entity tilemap = add_entity("tilemap");
   tilemap.add_component<tilemap_component>().tilemap = tm->id;
 
   // turn image into multiple entities with tiles


### PR DESCRIPTION
Basically, at line scene.h:46, the tilemap is created with `auto&` but it should be `ecs::entity` else the compiler with print an error which is: `cannot bind non-const lvalue reference of type ‘fuse::ecs::entity&’ to an rvalue of type ‘fuse::ecs::entity’`, meaning `auto&` didn't give the right entity type to the tilemap variable.